### PR TITLE
(DOCSP-43185) Fixing Deprecated Attribute in Webhook (ssl_verify) 

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -10,12 +11,6 @@ builds:
     goos:
       - linux
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -28,6 +23,6 @@ changelog:
       - '^test:'
 brews:
 - name: onboarder
-  tap:
+  repository:
     owner: terakilobyte
     name: homebrew-tools

--- a/githubops/githubactions.go
+++ b/githubops/githubactions.go
@@ -76,7 +76,6 @@ func addHooks(g *github.Client, repo globals.Repo, cfg *globals.Config) {
 					"url":          github.String(cfg.Hook.Url),
 					"content_type": github.String(cfg.Hook.ContentType),
 					"secret":       github.String(cfg.Hook.Secret),
-					"ssl_verify":   github.String(cfg.Hook.Secret),
 				},
 			})
 			if err != nil {

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -28,7 +28,6 @@ type Webhook struct {
 	Url         string `json:"url"`
 	ContentType string `json:"content_type"`
 	Secret      string `json:"secret"`
-	SSLVerify   string `json:"ssl_verify"`
 }
 type Collaborator struct {
 	Username   string `json:"username"`


### PR DESCRIPTION
- Deleted ssl_verify attribute from globals and githubactions
- updated .gorealeaser.yaml to remove deprecated attributes and add version header 