### PR TITLE
(DOCSP-43184) Removed deprecated attributes for Webhook generation an…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -10,12 +11,6 @@ builds:
     goos:
       - linux
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -28,6 +23,6 @@ changelog:
       - '^test:'
 brews:
 - name: onboarder
-  tap:
+  repository:
     owner: terakilobyte
     name: homebrew-tools

--- a/githubops/githubactions.go
+++ b/githubops/githubactions.go
@@ -76,7 +76,6 @@ func addHooks(g *github.Client, repo globals.Repo, cfg *globals.Config) {
 					"url":          github.String(cfg.Hook.Url),
 					"content_type": github.String(cfg.Hook.ContentType),
 					"secret":       github.String(cfg.Hook.Secret),
-					"ssl_verify":   github.String(cfg.Hook.Secret),
 				},
 			})
 			if err != nil {

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -28,7 +28,6 @@ type Webhook struct {
 	Url         string `json:"url"`
 	ContentType string `json:"content_type"`
 	Secret      string `json:"secret"`
-	SSLVerify   string `json:"ssl_verify"`
 }
 type Collaborator struct {
 	Username   string `json:"username"`


### PR DESCRIPTION
- [DOCSP-43184](https://jira.mongodb.org/browse/DOCSP-43184)

In githubactions.go and globals.go: 
- Removed deprecated attribute (ssl_verify) that prevented onboarder from adding Webhooks to forked repos. 

In .goreleaser.yaml: 
- Added **version: 2** header to prevent version error. 
- Removed deprecated **archive** attribute and replaced deprecated **tap** attribute with **repository**. 
